### PR TITLE
GCW-2794 fix for IE-11, that works on all browsers

### DIFF
--- a/stylesheets/logo-banner.css
+++ b/stylesheets/logo-banner.css
@@ -66,8 +66,8 @@
 }
 
 .goodcity-logo-banner .content .contributors .contributor.jockey_club.label {
-    margin-top: unset;
-    background-color: unset;
+    margin-top: 0;
+    background-color: transparent;
     color:#95a7b0;
 }
 


### PR DESCRIPTION
Hello all, 
This PR fixes the CSS for IE11, as `unset` is not supported by IE11, css wasn't getting applied. So used `background: transparent;` instead of `unset`.

Please review this PR

Thanks